### PR TITLE
refer original quacktrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Version: 1.0
 Author: ffddcchh
 
 made with Camomile
+
+Based on [quacktrip](http://msp.ucsd.edu/tools/quacktrip/) by Miller Puckette.


### PR DESCRIPTION
This may fix #1 


I'm not sure how Camomile works, but if the readme.md is always converted into that Quack4 tab on the 🌻  window of the vst, then it'll be nice.